### PR TITLE
Renaming of repository names to avoid name clashes

### DIFF
--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -17,15 +17,15 @@
 #
 
 FetchContent_Declare(
-	gtest
+	dep_gtest
 	GIT_REPOSITORY https://github.com/google/googletest.git
 	GIT_TAG release-1.10.0
 )
  
-FetchContent_GetProperties(gtest)
-if(NOT gtest_POPULATED)
-	FetchContent_Populate(gtest)
-	add_subdirectory(${gtest_SOURCE_DIR} ${gtest_BINARY_DIR} EXCLUDE_FROM_ALL)
+FetchContent_GetProperties(dep_gtest)
+if(NOT dep_gtest_POPULATED)
+	FetchContent_Populate(dep_gtest)
+	add_subdirectory(${dep_gtest_SOURCE_DIR} ${dep_gtest_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 


### PR DESCRIPTION
Renamed gtest to dep_gtest to avoid name clash which leads to gtest itself not compiling.